### PR TITLE
Fix syntax errors

### DIFF
--- a/testproxy.js
+++ b/testproxy.js
@@ -85,7 +85,7 @@ function getIpAddresses() {
 
 	return Object.keys(ifaces).reduce((prev, iface) =>
 			prev.concat(ifaces[iface].filter(address =>
-				!address.internal && address.family == 'IPv4',
+				!address.internal && address.family == 'IPv4'
 			))
 		, []);
 }
@@ -99,13 +99,13 @@ function startProxy(hostname, port, listenPort) {
 	let returnUrl;
 
 	proxy.on('proxyReq', proxyReq =>
-		proxyReq.setHeader('Host', hostname),
+		proxyReq.setHeader('Host', hostname)
 	);
 
 	const server = http.createServer((req, res) =>
 		proxy.web(req, res, {
-			target: `http://${hostname}:${port}`,
-		}),
+			target: `http://${hostname}:${port}`
+		})
 	);
 
 	server.listen(listenPort);
@@ -118,7 +118,7 @@ function startProxy(hostname, port, listenPort) {
 			const url = getUrl(ip.address, listenPort);
 			returnUrl = returnUrl || url;
 			console.log(`Listening on ${url}`);
-		},
+		}
 	);
 
 	return returnUrl;


### PR DESCRIPTION
Issues with syntax and closing `,`'s generating errors: 

Example:
```
testproxy.js:122
        );
        ^
SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:389:7)
    at startup (bootstrap_node.js:149:9)
```